### PR TITLE
Treat text arrowing-into the same as arrowing-out-of

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@macmillan-learning/mathquill",
-  "version": "0.10.1-c",
+  "version": "0.10.1-e",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@macmillan-learning/mathquill",
   "description": "Easily type math in your webapp",
-  "version": "0.10.1-d",
+  "version": "0.10.1-e",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -81,8 +81,8 @@ var TextBlock = P(Node, function(_, super_) {
   // and selection of the MathQuill tree, these all take in a direction and
   // the cursor
   _.moveTowards = function(dir, cursor) {
-    cursor.insAtDirEnd(-dir, this);
-    aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+    cursor.insDirOf(dir, this);
+    aria.queueDirOf(dir).queue(this);
   };
   _.moveOutOf = function(dir, cursor) {
     cursor.insDirOf(dir, this);


### PR DESCRIPTION
Deals with arrowing around \\text so you can't arrow into it.